### PR TITLE
fix(security): remediate shell injection in outside_contributor_dbt_v.1.8.6.yml (VULN-9332)

### DIFF
--- a/.github/workflows/outside_contributor_dbt_v1.8.6.yml
+++ b/.github/workflows/outside_contributor_dbt_v1.8.6.yml
@@ -1053,22 +1053,37 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Post comment on PR
+        env:
+          SQLFLUFF_LINT_RESULT: ${{ needs.sqlfluff-lint.result }}
+          BIGQUERY_CLINICAL_AND_CLAIMS_ENABLED_RESULT: ${{ needs.bigquery_clinical_and_claims_enabled.result }}
+          BIGQUERY_CLAIMS_ENABLED_RESULT: ${{ needs.bigquery_claims_enabled.result }}
+          BIGQUERY_CLINICAL_ENABLED_RESULT: ${{ needs.bigquery_clinical_enabled.result }}
+          FABRIC_CLINICAL_AND_CLAIMS_ENABLED_RESULT: ${{ needs.fabric_clinical_and_claims_enabled.result }}
+          FABRIC_CLAIMS_ENABLED_RESULT: ${{ needs.fabric_claims_enabled.result }}
+          FABRIC_CLINICAL_ENABLED_RESULT: ${{ needs.fabric_clinical_enabled.result }}
+          REDSHIFT_CLINICAL_AND_CLAIMS_ENABLED_RESULT: ${{ needs.redshift_clinical_and_claims_enabled.result }}
+          REDSHIFT_CLAIMS_ENABLED_RESULT: ${{ needs.redshift_claims_enabled.result }}
+          REDSHIFT_CLINICAL_ENABLED_RESULT: ${{ needs.redshift_clinical_enabled.result }}
+          SNOWFLAKE_CLINICAL_AND_CLAIMS_ENABLED_RESULT: ${{ needs.snowflake_clinical_and_claims_enabled.result }}
+          SNOWFLAKE_CLAIMS_ENABLED_RESULT: ${{ needs.snowflake_claims_enabled.result }}
+          SNOWFLAKE_CLINICAL_ENABLED_RESULT: ${{ needs.snowflake_clinical_enabled.result }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.inputs.prNumber }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_COMMENT="Workflow has finished with the following statuses:
-          <ul><li>Linter: ${{ needs.sqlfluff-lint.result }}</li></ul>
-          <ul><li>BigQuery Clinical and Claims: ${{ needs.bigquery_clinical_and_claims_enabled.result }}</li></ul>
-          <ul><li>BigQuery Claims: ${{ needs.bigquery_claims_enabled.result }}</li></ul>
-          <ul><li>BigQuery Clinical: ${{ needs.bigquery_clinical_enabled.result }}</li></ul>
-          <ul><li>Fabric Clinical and Claims: ${{ needs.fabric_clinical_and_claims_enabled.result }}</li></ul>
-          <ul><li>Fabric Claims: ${{ needs.fabric_claims_enabled.result }}</li></ul>
-          <ul><li>Fabric Clinical: ${{ needs.fabric_clinical_enabled.result }}</li></ul>
-          <ul><li>Redshift Clinical and Claims: ${{ needs.redshift_clinical_and_claims_enabled.result }}</li></ul>
-          <ul><li>Redshift Claims: ${{ needs.redshift_claims_enabled.result }}</li></ul>
-          <ul><li>Redshift Clinical: ${{ needs.redshift_clinical_enabled.result }}</li></ul>
-          <ul><li>Snowflake Clinical and Claims: ${{ needs.snowflake_clinical_and_claims_enabled.result }}</li></ul>
-          <ul><li>Snowflake Claims: ${{ needs.snowflake_claims_enabled.result }}</li></ul>
-          <ul><li>Snowflake Clinical: ${{ needs.snowflake_clinical_enabled.result }}</li></ul>"
-          PR_ID=$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.inputs.prNumber }} --json number -q .number)
-          gh pr comment $PR_ID --body "$PR_COMMENT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          <ul><li>Linter: $SQLFLUFF_LINT_RESULT</li></ul>
+          <ul><li>BigQuery Clinical and Claims: $BIGQUERY_CLINICAL_AND_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>BigQuery Claims: $BIGQUERY_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>BigQuery Clinical: $BIGQUERY_CLINICAL_ENABLED_RESULT</li></ul>
+          <ul><li>Fabric Clinical and Claims: $FABRIC_CLINICAL_AND_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Fabric Claims: $FABRIC_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Fabric Clinical: $FABRIC_CLINICAL_ENABLED_RESULT</li></ul>
+          <ul><li>Redshift Clinical and Claims: $REDSHIFT_CLINICAL_AND_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Redshift Claims: $REDSHIFT_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Redshift Clinical: $REDSHIFT_CLINICAL_ENABLED_RESULT</li></ul>
+          <ul><li>Snowflake Clinical and Claims: $SNOWFLAKE_CLINICAL_AND_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Snowflake Claims: $SNOWFLAKE_CLAIMS_ENABLED_RESULT</li></ul>
+          <ul><li>Snowflake Clinical: $SNOWFLAKE_CLINICAL_ENABLED_RESULT</li></ul>"
+          PR_ID=$(gh pr view "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER" --json number -q .number)
+          gh pr comment "$PR_ID" --body "$PR_COMMENT"


### PR DESCRIPTION
## Describe your changes
Move untrusted GitHub Actions context data (`needs.*.result`, `github.repository`, `github.event.inputs.prNumber`) out of the `run:` shell script and into env vars, referencing them via quoted environment variables instead of direct `${{ ... }}` interpolation. This prevents an attacker-controlled `prNumber` `workflow_dispatch` input from being interpreted as shell code on the runner.

This fixes [VULN-9332](https://includedhealth.atlassian.net/browse/VULN-9332), a SAST finding (`yaml.github-actions.security.run-shell-injection.run-shell-injection`) flagged in the `post_status_to_PR` job's "Post comment on PR" step of `.github/workflows/outside_contributor_dbt_v1.8.6.yml`.

## How has this been tested?
- Validated the updated workflow file parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
- Manually traced through the step to confirm the rendered `PR_COMMENT` and `gh pr view`/`gh pr comment` invocations produce the same behavior as before, now with all previously-interpolated values sourced from quoted environment variables instead of inline `${{ }}` expressions.
- Searched the rest of the workflow file for the same `${{ ... }}`-in-`run:` pattern to confirm no other steps have the same vulnerability.

## Reviewer focus
Please confirm the `post_status_to_PR` job still posts the expected PR comment (statuses list + `gh pr comment`) now that `github.repository`/`github.event.inputs.prNumber`/`needs.*.result` are passed via `env:` instead of inline template interpolation.

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link

[VULN-9332]: https://includedhealth.atlassian.net/browse/VULN-9332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI workflow hardening with no application or data-path changes; reviewers should confirm the PR comment still posts correctly.
> 
> **Overview**
> Fixes **shell injection** (VULN-9332) in the `post_status_to_PR` job’s **Post comment on PR** step in `outside_contributor_dbt_v1.8.6.yml`.
> 
> Previously, `needs.*.result`, `github.repository`, and `github.event.inputs.prNumber` were expanded inline inside the `run:` script via `${{ ... }}`, so a malicious `workflow_dispatch` `prNumber` could be interpreted as shell commands on the runner.
> 
> The step now maps those values under `env:` and the shell script reads them as **quoted** variables (`$PR_NUMBER`, `$GITHUB_REPOSITORY`, job result env vars). The PR status HTML comment and `gh pr view` / `gh pr comment` behavior stay the same; only how untrusted input reaches the shell changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e4336c1963181cb73005ec2e47e8238c7b5a08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->